### PR TITLE
LRDOCS-8732 Single page application support is toggled in liferay-portlet.xml, not portlet.xml

### DIFF
--- a/en/developer/frameworks/articles/portlets/07-using-javascript-in-your-portlets/09-spa/03-disabling-spa.markdown
+++ b/en/developer/frameworks/articles/portlets/07-using-javascript-in-your-portlets/09-spa/03-disabling-spa.markdown
@@ -6,20 +6,20 @@ header-id: disabling-spa
 
 [TOC levels=1-4]
 
-Certain elements of your page may require a regular navigation to work properly. 
-For example, you may have downloadable content that you want to share with the 
-user. In these cases, SPA must be disabled for those specific elements. You can 
+Certain elements of your page may require a regular navigation to work properly.
+For example, you may have downloadable content that you want to share with the
+user. In these cases, SPA must be disabled for those specific elements. You can
 disable SPA at these scopes:
 
 - disable SPA across an entire @product@ instance
 - disable SPA in a portlet
 - Disable SPA in individual elements
 
-Follow the steps in the corresponding section to disable SPA for that scope. 
+Follow the steps in the corresponding section to disable SPA for that scope.
 
 ## Disabling SPA across an Instance
 
-To disable SPA across an entire @product@ instance, add the following line to 
+To disable SPA across an entire @product@ instance, add the following line to
 your `portal-ext.properties`:
 
 ```properties
@@ -28,7 +28,7 @@ javascript.single.page.application.enabled = false
 
 ## Disabling SPA for a Portlet
 
-To disable SPA for a portlet, you must blacklist it. To blacklist a portlet from 
+To disable SPA for a portlet, you must blacklist it. To blacklist a portlet from
 SPA, follow these steps:
 
 1.  Open your portlet class.
@@ -39,14 +39,14 @@ SPA, follow these steps:
     com.liferay.portlet.single-page-application=false
     ```
 
-    If you prefer, you can set this property to false in your `portlet.xml` 
+    If you prefer, you can set this property to false in your `liferay-portlet.xml`
     instead by adding the following property to the `<portlet>` section:
 
     ```xml
     <single-page-application>false</single-page-application>
     ```
 
-3.  Alternatively, you can override the 
+3.  Alternatively, you can override the
     [`isSinglePageApplication` method](@platform-ref@/7.2-latest/javadocs/portal-impl/com/liferay/portal/model/impl/PortletImpl.html#isSinglePageApplication--)
     of the portlet to return `false`.
 
@@ -56,13 +56,13 @@ To disable SPA for a form or link follow these steps:
 
 1.  Add the `data-senna-off` attribute to the element.
 
-2.  Set the value to `true`. See the example below: 
+2.  Set the value to `true`. See the example below:
 
     ```html
     <a data-senna-off="true" href="/pages/page2.html">Page 2</a>
     ```
 
-Nice! Now you know how to disable SPA in your app. 
+Nice! Now you know how to disable SPA in your app.
 
 ## Related Topics
 


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LRDOCS-8732
Related article: https://help.liferay.com/hc/en-us/articles/360030752391-Disabling-SPA#disabling-spa-for-a-portlet

The code snippet shown in the article is supposed to be put in the liferay-portlet.xml file, since it processes Liferay-specific configs.

Changes made: 
- Change portlet.xml to liferay-portlet.xml
- Whitespace removal