### PR TITLE
LRDOCS-9454 Incomplete Command for 7.2 Theme Generator

### DIFF
--- a/en/developer/reference/articles/02-tooling/theme-generator/01-theme-generator-intro.markdown
+++ b/en/developer/reference/articles/02-tooling/theme-generator/01-theme-generator-intro.markdown
@@ -6,12 +6,12 @@ header-id: theme-generator
 
 [TOC levels=1-4]
 
-The Liferay Theme Generator generates themes for @product@. It is just one of 
-Liferay JS Theme Toolkit's 
-[tools](https://github.com/liferay/liferay-themes-sdk/tree/master/packages). 
+The Liferay Theme Generator generates themes for @product@. It is just one of
+Liferay JS Theme Toolkit's
+[tools](https://github.com/liferay/liferay-themes-sdk/tree/master/packages).
 
-A couple versions of the Liferay Theme Generator are available. The version you 
-must install depends on the version of @product@ you're developing on. The 
+A couple versions of the Liferay Theme Generator are available. The version you
+must install depends on the version of @product@ you're developing on. The
 required versions are listed in the table below:
 
 | Liferay Version | Liferay Theme Generator Version | Command |
@@ -19,11 +19,11 @@ required versions are listed in the table below:
 | 6.2 | 7.x.x | `npm install -g generator-liferay-theme@^7.x.x` |
 | 7.0 | 7.x.x or 8.x.x | Same as above or below |
 | 7.1 | 8.x.x | `npm install -g generator-liferay-theme@^8.x.x` |
-| 7.2 | 9.x.x | `npm install -g generator-liferay-theme |
+| 7.2 | 9.x.x | `npm install -g generator-liferay-theme@^9.x.x` |
 
 ## Sub-generators
 
-The Liferay Theme Generator includes the sub-generators listed in the table 
+The Liferay Theme Generator includes the sub-generators listed in the table
 below:
 
 | Sub-generator | Command to run | Description |
@@ -33,25 +33,25 @@ below:
 
 ### Layouts Sub-generator
 
-The Layouts sub-generator provides the controls to create a layout template 
-that meets your needs. You can add and remove rows and columns on-the-fly as you 
-require. See 
-[Generating Layout Templates](/docs/7-2/reference/-/knowledge_base/r/creating-layout-templates-with-the-themes-generator) 
-for more information. 
+The Layouts sub-generator provides the controls to create a layout template
+that meets your needs. You can add and remove rows and columns on-the-fly as you
+require. See
+[Generating Layout Templates](/docs/7-2/reference/-/knowledge_base/r/creating-layout-templates-with-the-themes-generator)
+for more information.
 
 ### Themelets Sub-generator
 
-Themelets are small, extendable, and reusable pieces of code. They only require 
-the CSS and/or JavaScript files that you want to add to your theme. This modular 
-approach reduces the need for duplicated code across themes and makes it easy 
-for developers to share code snippets with other developers. Themelets are 
-applicable for changes both small and large, from modifying the appearance of an 
-individual piece of UI to adding new features. If there is something you have to 
-manually code for every theme you create, it's a good candidate for a themelet. 
-See 
-[Generating Themelets](/docs/7-2/reference/-/knowledge_base/r/creating-themelets-with-the-themes-generator) 
-for more information. 
+Themelets are small, extendable, and reusable pieces of code. They only require
+the CSS and/or JavaScript files that you want to add to your theme. This modular
+approach reduces the need for duplicated code across themes and makes it easy
+for developers to share code snippets with other developers. Themelets are
+applicable for changes both small and large, from modifying the appearance of an
+individual piece of UI to adding new features. If there is something you have to
+manually code for every theme you create, it's a good candidate for a themelet.
+See
+[Generating Themelets](/docs/7-2/reference/-/knowledge_base/r/creating-themelets-with-the-themes-generator)
+for more information.
 
-While you can create themes using the tools you prefer, the Liferay Theme 
-Generator is designed with theme development for @product@ in mind. Its toolset 
+While you can create themes using the tools you prefer, the Liferay Theme
+Generator is designed with theme development for @product@ in mind. Its toolset
 and features help streamline theme development.

--- a/en/developer/reference/articles/02-tooling/theme-generator/01-theme-generator-intro.markdown
+++ b/en/developer/reference/articles/02-tooling/theme-generator/01-theme-generator-intro.markdown
@@ -14,22 +14,24 @@ A couple versions of the Liferay Theme Generator are available. The version you
 must install depends on the version of @product@ you're developing on. The
 required versions are listed in the table below:
 
-| Liferay Version | Liferay Theme Generator Version | Command |
-| --- | --- | --- |
-| 6.2 | 7.x.x | `npm install -g generator-liferay-theme@^7.x.x` |
-| 7.0 | 7.x.x or 8.x.x | Same as above or below |
-| 7.1 | 8.x.x | `npm install -g generator-liferay-theme@^8.x.x` |
-| 7.2 | 9.x.x | `npm install -g generator-liferay-theme@^9.x.x` |
+| Liferay Version | Liferay Theme Generator Version | Command                                         |
+|:----------------|:--------------------------------|:------------------------------------------------|
+| 6.2             | 7.x.x                           | `npm install -g generator-liferay-theme@^7.x.x` |
+| 7.0             | 7.x.x or 8.x.x                  | Same as above or below                          |
+| 7.1             | 8.x.x                           | `npm install -g generator-liferay-theme@^8.x.x` |
+| 7.2             | 9.x.x                           | `npm install -g generator-liferay-theme@^9.x.x` |
+
+See [Version Compatibility Matrix](https://learn.liferay.com/w/dxp/building-applications/tooling/reference/node-version-information#version-compatibility-matrix) for more information.
 
 ## Sub-generators
 
 The Liferay Theme Generator includes the sub-generators listed in the table
 below:
 
-| Sub-generator | Command to run | Description |
-| --- | --- | --- |
-| Layouts | `yo liferay-theme:layout` | Generate layout templates with an interactive VIM. |
-| Themelets | `yo liferay-theme:themelet` | Create small, reusable, pieces of CSS and HTML for your themes. |
+| Sub-generator | Command to run              | Description                                                     |
+|:--------------|:----------------------------|:----------------------------------------------------------------|
+| Layouts       | `yo liferay-theme:layout`   | Generate layout templates with an interactive VIM.              |
+| Themelets     | `yo liferay-theme:themelet` | Create small, reusable, pieces of CSS and HTML for your themes. |
 
 ### Layouts Sub-generator
 


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LRDOCS-9454
Related article: https://help.liferay.com/hc/en-us/articles/360029147711

The command to install the 9.x.x version of generator-liferay-theme for 7.2 DXP was incomplete.

Changes made:
- Fix incomplete command for 7.2 Theme Generator
- Whitespace removal