### PR TITLE
LRDOCS-7566 Note needed for npm Vue.js Portlet Template

### DIFF
--- a/develop/reference/articles/12-project-templates/19-npm-vuejs-portlet-template.markdown
+++ b/develop/reference/articles/12-project-templates/19-npm-vuejs-portlet-template.markdown
@@ -57,6 +57,9 @@ or
         -DpackageJsonVersion=1.0.0 \
         -DliferayVersion=7.0
 
+**Important:** This sample works for Liferay DXP 7.0 Fix Pack 44+ and Liferay Portal
+CE GA7+.
+
 After running the command above, your project's directory structure looks like
 this:
 

--- a/develop/reference/articles/12-project-templates/19-npm-vuejs-portlet-template.markdown
+++ b/develop/reference/articles/12-project-templates/19-npm-vuejs-portlet-template.markdown
@@ -64,10 +64,10 @@ After running the command above, your project's directory structure looks like
 this:
 
 - `my-npm-vuejs-portlet`
-    - `[gradle|.mvn]`
+    - `.mvn` (only in Maven Blade CLI generated projects)
         - `wrapper`
-            - `[gradle|maven]-wrapper.jar`
-            - `[gradle|maven]-wrapper.properties`
+            - `maven-wrapper.jar`
+            - `maven-wrapper.properties`
     - `src`
         - `main`
             - `java`
@@ -81,7 +81,7 @@ this:
                     - `Language.properties`
                 - `META-INF`
                     - `resources`
-                        - `js`
+                        - `lib`
                             - `index.es.js`
                         - `init.jsp`
                         - `view.jsp`
@@ -89,7 +89,8 @@ this:
     - `.npmbundlerrc`
     - `bnd.bnd`
     - `[build.gradle|pom.xml]`
-    - `[gradlew|mvnw]`
+    - `mvnw` (only in Maven Blade CLI generated projects)
+    - `mvnw.cmd` (only in Maven Blade CLI generated projects)
     - `package.json`
 
 The generated module is a working application and is deployable to a @product@


### PR DESCRIPTION
Jira ticket: https://liferay.atlassian.net/browse/LRDOCS-7566
Related article: https://help.liferay.com/hc/en-us/articles/360017891312

The npm Vue.js Portlet was only implemented after DXP 7.0 Fix Pack 44+ or Portal CE GA7+. This information is important, since the reader needs to know the version in order for the portlet deployment work.

Changes made: 
- Add important admonition for the portlet's compatible version
Fix outdated information